### PR TITLE
Proposal: support react-router-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Fork and branch to support react-router-dom 4.
+
+Npm install:
+
+    npm install react-router-dom
+
 # React-router externs for Haxe
 
 Simple externs for [react-router](https://github.com/ReactTraining/react-router) 3.0.0+ (not 4!)
@@ -7,14 +13,14 @@ for use with [Haxe react](https://github.com/massiveinteractive/haxe-react) 1.0.
   var history = ReactRouter.browserHistory;
 
   var app = ReactDOM.render(jsx('
-  
+
     <Router history=$history>
       <Route path="/" component=$PageWrapper>
         <IndexRoute component=$HomeView/>
         <Route path="about" component=$AboutView/>
       </Route>
     </Router>
-      
+
   '), rootElement);
 ```
 

--- a/router/IndexLink.hx
+++ b/router/IndexLink.hx
@@ -1,7 +1,7 @@
 package router;
 
 // like Link with 'onlyActiveOnIndex' true
-@:jsRequire('react-router', 'IndexLink')
+@:jsRequire('react-router-dom', 'IndexLink')
 extern class IndexLink extends Link
 {
 }

--- a/router/Link.hx
+++ b/router/Link.hx
@@ -19,7 +19,7 @@ typedef LinkProps = {
 	?rel:String
 }
 
-@:jsRequire('react-router', 'Link')
+@:jsRequire('react-router-dom', 'Link')
 extern class Link extends ReactComponentOfProps<LinkProps>
 {
 }

--- a/router/ReactRouter.hx
+++ b/router/ReactRouter.hx
@@ -8,8 +8,8 @@ typedef RouterHistory = Dynamic;
  * React-router API
  * https://github.com/ReactTraining/react-router/blob/master/docs/API.md
  */
-@:jsRequire('react-router')
-extern class ReactRouter 
+@:jsRequire('react-router-dom')
+extern class ReactRouter
 {
 	/** HTML5 history */
 	static public var browserHistory:RouterHistory;
@@ -28,7 +28,7 @@ typedef RouterProps = {
 	?render:Dynamic->ReactElement //<RouterContext>
 }
 
-@:jsRequire('react-router', 'Router')
+@:jsRequire('react-router-dom', 'Router')
 extern class Router extends ReactComponentOfProps<RouterProps>
 {
 	public var location:RouterLocation;
@@ -63,13 +63,13 @@ typedef RouteProps = {>BaseRouteProps,
 	path:String
 }
 
-@:jsRequire('react-router', 'Route')
+@:jsRequire('react-router-dom', 'Route')
 extern class Route extends ReactComponentOfProps<RouteProps>
 {
 }
 
 
-@:jsRequire('react-router', 'IndexRoute')
+@:jsRequire('react-router-dom', 'IndexRoute')
 extern class IndexRoute extends ReactComponentOfProps<BaseRouteProps>
 {
 }
@@ -80,7 +80,7 @@ typedef RedirectProps = {
 	to:Dynamic
 }
 
-@:jsRequire('react-router', 'Redirect')
+@:jsRequire('react-router-dom', 'Redirect')
 extern class Redirect extends ReactComponentOfProps<RedirectProps>
 {
 }
@@ -90,7 +90,7 @@ typedef IndexRedirectProps = {
 	to:Dynamic
 }
 
-@:jsRequire('react-router', 'IndexRedirect')
+@:jsRequire('react-router-dom', 'IndexRedirect')
 extern class IndexRedirect extends ReactComponentOfProps<IndexRedirectProps>
 {
 }


### PR DESCRIPTION
Hi. This is a proposal, interested in your feedback.

I'm using `react-router-dom:4+`. The `require` imports are slightly different. Do you want to put this on a "version4" branch or similar? I'd rather keep these libs in the same repo, not have personal forks. 